### PR TITLE
fix module reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "rsk",
     "rskswap"
   ],
-  "module": "dist/sdk.esm.js",
+  "module": "dist/rskswap-sdk.esm.js",
   "scripts": {
     "lint": "tsdx lint src test",
     "build": "tsdx build",


### PR DESCRIPTION
There is an issue with the `module` field in the `package.json` that is causing my bundler to throw when integrating my RSKSwap into my dapp
